### PR TITLE
Remove UIKit import in LCS.swift

### DIFF
--- a/Dwifft/LCS.swift
+++ b/Dwifft/LCS.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 jflinter. All rights reserved.
 //
 
-import UIKit
-
 /// These get returned from calls to LCS.diff(). They represent insertions or deletions that need to happen to transform array a into array b.
 public enum ArrayDiffResult : DebugPrintable {
     case Insert(Int)


### PR DESCRIPTION
This isn’t required to compile - everything used in the file is available in plain Swift, and it adds a dependency on iOS as the target platform for `LCS.swift`.