### PR TITLE
DiffStep - Made 'idx' and 'value' properties public

### DIFF
--- a/Dwifft/Dwifft.swift
+++ b/Dwifft/Dwifft.swift
@@ -51,7 +51,7 @@ public enum DiffStep<T> : CustomDebugStringConvertible {
             return "-\(j)@\(i)"
         }
     }
-    var idx: Int {
+    public var idx: Int {
         switch(self) {
         case .Insert(let i, _):
             return i
@@ -59,7 +59,7 @@ public enum DiffStep<T> : CustomDebugStringConvertible {
             return i
         }
     }
-    var value: T {
+    public var value: T {
         switch(self) {
         case .Insert(let j):
             return j.1


### PR DESCRIPTION
Just a small PR, the `idx` and `value` properties on `DiffStep` were not flagged as public so I couldn't access them in my apps module.

I didn't see a reason on why these needed to be internal so thought i'd file a PR :)

Great job btw! 