### PR TITLE
run swift3 migrator

### DIFF
--- a/Dwifft.xcodeproj/project.pbxproj
+++ b/Dwifft.xcodeproj/project.pbxproj
@@ -168,14 +168,16 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = jflinter;
 				TargetAttributes = {
 					041EBB911B89679200E113B3 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 					};
 					041EBB9C1B89679200E113B3 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -258,8 +260,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -307,8 +311,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -328,6 +334,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -338,6 +345,7 @@
 		041EBBA91B89679200E113B3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -348,12 +356,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		041EBBAA1B89679200E113B3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -364,6 +374,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -378,6 +389,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -388,6 +400,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Dwifft.xcodeproj/xcshareddata/xcschemes/Dwifft.xcscheme
+++ b/Dwifft.xcodeproj/xcshareddata/xcschemes/Dwifft.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Dwifft/Dwifft+UIKit.swift
+++ b/Dwifft/Dwifft+UIKit.swift
@@ -10,9 +10,9 @@
 
 import UIKit
 
-public class TableViewDiffCalculator<T: Equatable> {
+open class TableViewDiffCalculator<T: Equatable> {
     
-    public weak var tableView: UITableView?
+    open weak var tableView: UITableView?
     
     public init(tableView: UITableView, initialRows: [T] = []) {
         self.tableView = tableView
@@ -20,13 +20,13 @@ public class TableViewDiffCalculator<T: Equatable> {
     }
     
     /// Right now this only works on a single section of a tableView. If your tableView has multiple sections, though, you can just use multiple TableViewDiffCalculators, one per section, and set this value appropriately on each one.
-    public var sectionIndex: Int = 0
+    open var sectionIndex: Int = 0
     
     /// You can change insertion/deletion animations like this! Fade works well. So does Top/Bottom. Left/Right/Middle are a little weird, but hey, do your thing.
-    public var insertionAnimation = UITableViewRowAnimation.Automatic, deletionAnimation = UITableViewRowAnimation.Automatic
+    open var insertionAnimation = UITableViewRowAnimation.automatic, deletionAnimation = UITableViewRowAnimation.automatic
     
     /// Change this value to trigger animations on the table view.
-    public var rows : [T] {
+    open var rows : [T] {
         didSet {
             
             let oldRows = oldValue
@@ -35,11 +35,11 @@ public class TableViewDiffCalculator<T: Equatable> {
             if (diff.results.count > 0) {
                 tableView?.beginUpdates()
                 
-                let insertionIndexPaths = diff.insertions.map({ NSIndexPath(forRow: $0.idx, inSection: self.sectionIndex) })
-                let deletionIndexPaths = diff.deletions.map({ NSIndexPath(forRow: $0.idx, inSection: self.sectionIndex) })
+                let insertionIndexPaths = diff.insertions.map({ IndexPath(row: $0.idx, section: self.sectionIndex) })
+                let deletionIndexPaths = diff.deletions.map({ IndexPath(row: $0.idx, section: self.sectionIndex) })
                 
-                tableView?.insertRowsAtIndexPaths(insertionIndexPaths, withRowAnimation: insertionAnimation)
-                tableView?.deleteRowsAtIndexPaths(deletionIndexPaths, withRowAnimation: deletionAnimation)
+                tableView?.insertRows(at: insertionIndexPaths, with: insertionAnimation)
+                tableView?.deleteRows(at: deletionIndexPaths, with: deletionAnimation)
                 
                 tableView?.endUpdates()
             }
@@ -49,9 +49,9 @@ public class TableViewDiffCalculator<T: Equatable> {
     
 }
     
-public class CollectionViewDiffCalculator<T: Equatable> {
+open class CollectionViewDiffCalculator<T: Equatable> {
     
-    public weak var collectionView: UICollectionView?
+    open weak var collectionView: UICollectionView?
     
     public init(collectionView: UICollectionView, initialRows: [T] = []) {
         self.collectionView = collectionView
@@ -59,22 +59,22 @@ public class CollectionViewDiffCalculator<T: Equatable> {
     }
     
     /// Right now this only works on a single section of a collectionView. If your collectionView has multiple sections, though, you can just use multiple CollectionViewDiffCalculators, one per section, and set this value appropriately on each one.
-    public var sectionIndex: Int = 0
+    open var sectionIndex: Int = 0
     
     /// Change this value to trigger animations on the collection view.
-    public var rows : [T] {
+    open var rows : [T] {
         didSet {
             
             let oldRows = oldValue
             let newRows = self.rows
             let diff = oldRows.diff(newRows)
             if (diff.results.count > 0) {
-                let insertionIndexPaths = diff.insertions.map({ NSIndexPath(forItem: $0.idx, inSection: self.sectionIndex) })
-                let deletionIndexPaths = diff.deletions.map({ NSIndexPath(forItem: $0.idx, inSection: self.sectionIndex) })
+                let insertionIndexPaths = diff.insertions.map({ IndexPath(item: $0.idx, section: self.sectionIndex) })
+                let deletionIndexPaths = diff.deletions.map({ IndexPath(item: $0.idx, section: self.sectionIndex) })
                 
                 collectionView?.performBatchUpdates({ () -> Void in
-                    self.collectionView?.insertItemsAtIndexPaths(insertionIndexPaths)
-                    self.collectionView?.deleteItemsAtIndexPaths(deletionIndexPaths)
+                    self.collectionView?.insertItems(at: insertionIndexPaths)
+                    self.collectionView?.deleteItems(at: deletionIndexPaths)
                 }, completion: nil)
             }
             

--- a/DwifftTests/DwifftTests.swift
+++ b/DwifftTests/DwifftTests.swift
@@ -39,7 +39,7 @@ class DwifftTests: XCTestCase {
             XCTAssertEqual(test.array1.LCS(test.array2), test.expectedLCS, "incorrect LCS")
             
             let diff = test.array1.diff(test.array2)
-            let printableDiff = diff.results.map({ $0.debugDescription }).joinWithSeparator("")
+            let printableDiff = diff.results.map({ $0.debugDescription }).joined(separator: "")
             XCTAssertEqual(printableDiff, test.expectedDiff, "incorrect diff")
             
             let applied = test.array1.apply(diff)
@@ -63,24 +63,24 @@ class DwifftTests: XCTestCase {
             init(insertionExpectations: [Int: XCTestExpectation], deletionExpectations: [Int: XCTestExpectation]) {
                 self.insertionExpectations = insertionExpectations
                 self.deletionExpectations = deletionExpectations
-                super.init(frame: CGRectZero, style: UITableViewStyle.Plain)
+                super.init(frame: CGRect.zero, style: UITableViewStyle.plain)
             }
             
             required init?(coder aDecoder: NSCoder) {
                 fatalError("not implemented")
             }
             
-            private override func insertRowsAtIndexPaths(indexPaths: [NSIndexPath], withRowAnimation animation: UITableViewRowAnimation) {
-                XCTAssertEqual(animation, UITableViewRowAnimation.Left, "incorrect insertion animation")
+            fileprivate override func insertRows(at indexPaths: [IndexPath], with animation: UITableViewRowAnimation) {
+                XCTAssertEqual(animation, UITableViewRowAnimation.left, "incorrect insertion animation")
                 for indexPath in indexPaths {
-                    self.insertionExpectations[indexPath.row]!.fulfill()
+                    self.insertionExpectations[(indexPath as NSIndexPath).row]!.fulfill()
                 }
             }
             
-            private override func deleteRowsAtIndexPaths(indexPaths: [NSIndexPath], withRowAnimation animation: UITableViewRowAnimation) {
-                XCTAssertEqual(animation, UITableViewRowAnimation.Right, "incorrect insertion animation")
+            fileprivate override func deleteRows(at indexPaths: [IndexPath], with animation: UITableViewRowAnimation) {
+                XCTAssertEqual(animation, UITableViewRowAnimation.right, "incorrect insertion animation")
                 for indexPath in indexPaths {
-                    self.deletionExpectations[indexPath.row]!.fulfill()
+                    self.deletionExpectations[(indexPath as NSIndexPath).row]!.fulfill()
                 }
             }
             
@@ -99,8 +99,8 @@ class DwifftTests: XCTestCase {
             init(tableView: TestTableView, rows: [Int]) {
                 self.tableView = tableView
                 self.diffCalculator = TableViewDiffCalculator<Int>(tableView: tableView, initialRows: rows)
-                self.diffCalculator.insertionAnimation = .Left
-                self.diffCalculator.deletionAnimation = .Right
+                self.diffCalculator.insertionAnimation = .left
+                self.diffCalculator.deletionAnimation = .right
                 self.rows = rows
                 super.init(nibName: nil, bundle: nil)
             }
@@ -109,11 +109,11 @@ class DwifftTests: XCTestCase {
                 fatalError("not implemented")
             }
             
-            @objc func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+            @objc func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
                 return UITableViewCell()
             }
             
-            @objc func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+            @objc func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
                 return rows.count
             }
             
@@ -121,20 +121,20 @@ class DwifftTests: XCTestCase {
         
         var insertionExpectations: [Int: XCTestExpectation] = [:]
         for i in [0, 3, 4, 5] {
-            let x: XCTestExpectation = expectationWithDescription("+\(i)")
+            let x: XCTestExpectation = expectation(description: "+\(i)")
             insertionExpectations[i] = x
         }
         
         var deletionExpectations: [Int: XCTestExpectation] = [:]
         for i in [0, 1, 2, 4] {
-            let x: XCTestExpectation = expectationWithDescription("+\(i)")
+            let x: XCTestExpectation = expectation(description: "+\(i)")
             deletionExpectations[i] = x
         }
         
         let tableView = TestTableView(insertionExpectations: insertionExpectations, deletionExpectations: deletionExpectations)
         let viewController = TestViewController(tableView: tableView, rows: [0, 1, 2, 5, 8, 9, 0])
         viewController.rows = [4, 5, 9, 8, 3, 1, 0]
-        waitForExpectationsWithTimeout(1.0, handler: nil)
+        waitForExpectations(timeout: 1.0, handler: nil)
     }
     
     func testCollectionViewDiffCalculator() {
@@ -147,22 +147,22 @@ class DwifftTests: XCTestCase {
             init(insertionExpectations: [Int: XCTestExpectation], deletionExpectations: [Int: XCTestExpectation]) {
                 self.insertionExpectations = insertionExpectations
                 self.deletionExpectations = deletionExpectations
-                super.init(frame: CGRectZero, collectionViewLayout: UICollectionViewFlowLayout())
+                super.init(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
             }
             
             required init?(coder aDecoder: NSCoder) {
                 fatalError("not implemented")
             }
             
-            private override func insertItemsAtIndexPaths(indexPaths: [NSIndexPath]) {
+            fileprivate override func insertItems(at indexPaths: [IndexPath]) {
                 for indexPath in indexPaths {
-                    self.insertionExpectations[indexPath.item]!.fulfill()
+                    self.insertionExpectations[(indexPath as NSIndexPath).item]!.fulfill()
                 }
             }
             
-            private override func deleteItemsAtIndexPaths(indexPaths: [NSIndexPath]) {
+            fileprivate override func deleteItems(at indexPaths: [IndexPath]) {
                 for indexPath in indexPaths {
-                    self.deletionExpectations[indexPath.item]!.fulfill()
+                    self.deletionExpectations[(indexPath as NSIndexPath).item]!.fulfill()
                 }
             }
             
@@ -189,11 +189,11 @@ class DwifftTests: XCTestCase {
                 fatalError("not implemented")
             }
             
-            @objc func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+            @objc func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
                 return rows.count
             }
             
-            @objc func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+            @objc func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
                 return UICollectionViewCell()
             }
             
@@ -201,20 +201,20 @@ class DwifftTests: XCTestCase {
         
         var insertionExpectations: [Int: XCTestExpectation] = [:]
         for i in [0, 3, 4, 5] {
-            let x: XCTestExpectation = expectationWithDescription("+\(i)")
+            let x: XCTestExpectation = expectation(description: "+\(i)")
             insertionExpectations[i] = x
         }
         
         var deletionExpectations: [Int: XCTestExpectation] = [:]
         for i in [0, 1, 2, 4] {
-            let x: XCTestExpectation = expectationWithDescription("+\(i)")
+            let x: XCTestExpectation = expectation(description: "+\(i)")
             deletionExpectations[i] = x
         }
         
         let collectionView = TestCollectionView(insertionExpectations: insertionExpectations, deletionExpectations: deletionExpectations)
         let viewController = TestViewController(collectionView: collectionView, rows: [0, 1, 2, 5, 8, 9, 0])
         viewController.rows = [4, 5, 9, 8, 3, 1, 0]
-        waitForExpectationsWithTimeout(1.0, handler: nil)
+        waitForExpectations(timeout: 1.0, handler: nil)
     }
     
 }


### PR DESCRIPTION
When you are ready to migrate the code to swift 3, I updated the code using the migrator. 
Tests are passing!

Quick question is TableViewDiffCalculator intended to be subclassed? the migrator set the privacy to open but you might want to set it to public to restrict people from subclassing it