### PR TITLE
Avoid NSInternalStateInconsistencyException by setting rows inside performBatchUpdates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 osx_image: xcode8
 language: objective-c
-script: xcodebuild test -project Dwifft.xcodeproj -scheme Dwifft -sdk iphonesimulator10.0 -destination 'platform=iOS Simulator,name=iPhone 7'
+script: set -o pipefail && xcodebuild test -project Dwifft.xcodeproj -scheme Dwifft -sdk iphonesimulator10.0 -destination 'platform=iOS Simulator,name=iPhone 7' | xcpretty -c

--- a/Dwifft/Dwifft+UIKit.swift
+++ b/Dwifft/Dwifft+UIKit.swift
@@ -24,7 +24,7 @@ open class TableViewDiffCalculator<T: Equatable> {
     
     /// You can change insertion/deletion animations like this! Fade works well. So does Top/Bottom. Left/Right/Middle are a little weird, but hey, do your thing.
     open var insertionAnimation = UITableViewRowAnimation.automatic, deletionAnimation = UITableViewRowAnimation.automatic
-    
+
     /// Change this value to trigger animations on the table view.
     open var rows : [T] {
         willSet {
@@ -53,24 +53,31 @@ open class CollectionViewDiffCalculator<T: Equatable> {
     
     public init(collectionView: UICollectionView, initialRows: [T] = []) {
         self.collectionView = collectionView
-        self.rows = initialRows
+        _rows = initialRows
     }
     
     /// Right now this only works on a single section of a collectionView. If your collectionView has multiple sections, though, you can just use multiple CollectionViewDiffCalculators, one per section, and set this value appropriately on each one.
     open var sectionIndex: Int = 0
-    
+
+    // Since UICollectionView (unlike UITableView) takes a block which must update its data source and trigger animations, we need to trigger the changes on set, instead of explicitly before and after set. This backing array lets us use a getter/setter in the exposed property.
+    private var _rows: [T]
+
     /// Change this value to trigger animations on the collection view.
     open var rows : [T] {
-        didSet {
-            
-            let oldRows = oldValue
-            let newRows = self.rows
+        get {
+            return _rows
+        }
+        set {
+            let oldRows = rows
+            let newRows = newValue
             let diff = oldRows.diff(newRows)
             if (diff.results.count > 0) {
-                let insertionIndexPaths = diff.insertions.map({ IndexPath(item: $0.idx, section: self.sectionIndex) })
-                let deletionIndexPaths = diff.deletions.map({ IndexPath(item: $0.idx, section: self.sectionIndex) })
-                
                 collectionView?.performBatchUpdates({ () -> Void in
+                    self._rows = newValue
+
+                    let insertionIndexPaths = diff.insertions.map({ IndexPath(item: $0.idx, section: self.sectionIndex) })
+                    let deletionIndexPaths = diff.deletions.map({ IndexPath(item: $0.idx, section: self.sectionIndex) })
+
                     self.collectionView?.insertItems(at: insertionIndexPaths)
                     self.collectionView?.deleteItems(at: deletionIndexPaths)
                 }, completion: nil)

--- a/Dwifft/Dwifft+UIKit.swift
+++ b/Dwifft/Dwifft+UIKit.swift
@@ -16,7 +16,7 @@ open class TableViewDiffCalculator<T: Equatable> {
     
     public init(tableView: UITableView, initialRows: [T] = []) {
         self.tableView = tableView
-        self.rows = initialRows
+        self._rows = initialRows
     }
     
     /// Right now this only works on a single section of a tableView. If your tableView has multiple sections, though, you can just use multiple TableViewDiffCalculators, one per section, and set this value appropriately on each one.
@@ -26,22 +26,25 @@ open class TableViewDiffCalculator<T: Equatable> {
     open var insertionAnimation = UITableViewRowAnimation.automatic, deletionAnimation = UITableViewRowAnimation.automatic
 
     /// Change this value to trigger animations on the table view.
+    private var _rows: [T]
     open var rows : [T] {
-        willSet {
-            tableView?.beginUpdates()
+        get {
+            return _rows
         }
-        didSet {
-            let oldRows = oldValue
-            let newRows = self.rows
+        set {
+            let oldRows = rows
+            let newRows = newValue
             let diff = oldRows.diff(newRows)
             if (diff.results.count > 0) {
+                tableView?.beginUpdates()
+                self._rows = newValue
                 let insertionIndexPaths = diff.insertions.map({ IndexPath(row: $0.idx, section: self.sectionIndex) })
                 let deletionIndexPaths = diff.deletions.map({ IndexPath(row: $0.idx, section: self.sectionIndex) })
-                
+
                 tableView?.insertRows(at: insertionIndexPaths, with: insertionAnimation)
                 tableView?.deleteRows(at: deletionIndexPaths, with: deletionAnimation)
+                tableView?.endUpdates()
             }
-            tableView?.endUpdates()
         }
     }
     

--- a/DwifftTests/DwifftTests.swift
+++ b/DwifftTests/DwifftTests.swift
@@ -155,12 +155,14 @@ class DwifftTests: XCTestCase {
             }
             
             private override func insertItems(at indexPaths: [IndexPath]) {
+                super.insertItems(at: indexPaths)
                 for indexPath in indexPaths {
                     self.insertionExpectations[(indexPath as NSIndexPath).item]!.fulfill()
                 }
             }
             
             private override func deleteItems(at indexPaths: [IndexPath]) {
+                super.deleteItems(at: indexPaths)
                 for indexPath in indexPaths {
                     self.deletionExpectations[(indexPath as NSIndexPath).item]!.fulfill()
                 }
@@ -183,6 +185,9 @@ class DwifftTests: XCTestCase {
                 self.diffCalculator = CollectionViewDiffCalculator<Int>(collectionView: self.testCollectionView, initialRows: rows)
                 self.rows = rows
                 super.init(nibName: nil, bundle: nil)
+
+                collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "TestCell")
+                collectionView.dataSource = self
             }
             
             required init?(coder aDecoder: NSCoder) {
@@ -190,11 +195,11 @@ class DwifftTests: XCTestCase {
             }
             
             @objc func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-                return rows.count
+                return diffCalculator.rows.count
             }
             
             @objc func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-                return UICollectionViewCell()
+                return collectionView.dequeueReusableCell(withReuseIdentifier: "TestCell", for: indexPath)
             }
             
         }


### PR DESCRIPTION
This solves the issue I was having related to #21. This change replaces the `didSet` observer on `rows` with a setter. Modifying `rows` now works like this:

1. `rows` is assigned to, which calls its `set` setter 
2. The setter computes a diff from the previous value of `rows`.
3. If the diff indicates any changes, the setter calls `performBatchUpdates`. Inside the block, it modifies the backing array for `rows` and triggers any necessary animations.

Previously, `CollectionViewDiffCalculator` changed its backing values by modifying `rows` first, then invoking a `didSet` observer. Like I documented for table views in #23, the modification to `rows` needs to happen after the collection view has been informed a block of changes is incoming. 

I also updated the test for `CollectionViewDiffCalculator` to invoke UIKit so that it catches these kinds of errors in testing.