### PR TITLE
Remove redundant recursive call for lcsFromIndices(_: _: _: _: _:)

### DIFF
--- a/Dwifft/Dwifft.swift
+++ b/Dwifft/Dwifft.swift
@@ -119,12 +119,8 @@ public extension Array where Element: Equatable {
     
     /// Walks back through the generated table to generate the LCS.
     fileprivate static func lcsFromIndices(_ table: [[Int]], _ x: [Element], _ y: [Element], _ i: Int, _ j: Int) -> [Element] {
-        if i == 0 && j == 0 {
+        if i == 0 || j == 0 {
             return []
-        } else if i == 0 {
-            return lcsFromIndices(table, x, y, i, j - 1)
-        } else if j == 0 {
-            return lcsFromIndices(table, x, y, i - 1, j)
         } else if x[i-1] == y[j-1] {
             return lcsFromIndices(table, x, y, i - 1, j - 1) + [x[i - 1]]
         } else if table[i-1][j] > table[i][j-1] {


### PR DESCRIPTION
for i == 0 or j == 0, we could direct return an empty array. 

Original implementation contains redundant recursive call, since we already know that i == 0 or j == 0, either way it will fall through down to ( i == 0 && j == 0) case. 

So I think early return will make the code more efficient.