### PR TITLE
Support for tvOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,31 @@
-osx_image: xcode8
-language: objective-c
-before_script: carthage bootstrap --platform ios --configuration Debug
-script: set -o pipefail && xcodebuild clean build build-for-testing  -project Dwifft.xcodeproj -scheme Dwifft -sdk iphonesimulator10.0 -destination 'platform=iOS Simulator,name=iPhone 7' | xcpretty -c && xcodebuild test-without-building -project Dwifft.xcodeproj -scheme Dwifft -sdk iphonesimulator10.0 -destination 'platform=iOS Simulator,name=iPhone 7' | xcpretty -c
+matrix:
+  include:
+    - os: osx
+      language: objective-c
+      osx_image: xcode8
+      env:
+        - PLATFORM=iOS NAME='iPhone 7'
+      before_install:
+        export UUID=$(instruments -s | ruby -e "ARGF.each_line{ |ln| ln =~ /$NAME .* \[(.*)\]/; if \$1; puts(\$1); exit; end }");
+      before_script:
+        carthage bootstrap --platform $PLATFORM --configuration Debug
+      script:
+        - set -o pipefail;
+          open -a "simulator" --args -CurrentDeviceUDID "$UUID"
+          xcodebuild -scheme Dwifft -destination "id=$UUID" test | xcpretty;
+    - os: osx
+      language: objective-c
+      osx_image: xcode8
+      env:
+        - PLATFORM=tvOS NAME='Apple TV 1080p'
+      before_install:
+        export UUID=$(instruments -s | ruby -e "ARGF.each_line{ |ln| ln =~ /$NAME .* \[(.*)\]/; if \$1; puts(\$1); exit; end }");
+      before_script:
+        carthage bootstrap --platform $PLATFORM --configuration Debug
+      script:
+        - set -o pipefail;
+          open -a "simulator" --args -CurrentDeviceUDID "$UUID"
+          xcodebuild -scheme Dwifft -destination "id=$UUID" test | xcpretty;
 env:
   global:
     secure: pUV8Ccwq1FWO8PxTHPQ3qZDUDhjNOisNVRyrziYR8x0ZQYjmVmnaLKaOHFP8co6rhBlFqReKUjoFYgRqP5QK1EkD6lqSZfnkrWqnZuLDNy0sn3/+4sLtvqAhBroAfjmmvb5GpY+Kkqfz8Lhdu6+1Z/a5xPhqNeDO3aDpa2vdBztb2qLIZnf2g8NFLOoNuR+ula868nIm858LCN1sqLp9PhV4CGaMsFx7ZFaX1yEQbwNb8+85+U2HIHqjZ62u9KZ4lA1d58VVDGj2f7ObKkC+pjiuknljy5bvRVvg5pttXggJracFgMqouwwQFFCV3nFYSDS6h7ZIjUvbyMrqBN+u32RmtqVLp1by1JvRXSeemJ3HxtZGLbq7rff4zWXyYbelT6sR6J1tWIubRo5v3sXc8E1kurqKkcPqJdG4jqiUXOau2oSHhf7WCRwa0KNfvaQuMhm0Onnsi9tW2MzGieumscfuFIJsXJdXnac7jQUVb571GfxMrDeJ9v2GOPcbnlM8cttBFAw4IoINV6teKITUW6T8RpeDXzfQyxDDQaV0M1ZTab1Tj/f4EYDAXKfZ+QquWK3bgXJhxKghXIskZLdDhYMyP55T6QxLZY9wD2CxLrEbEhDQCEb+7R2LmIC95Rlku+W92b8eWAqNxf+vV7QRqBb/sV9w2mlxmmezYTP5VAs=

--- a/Dwifft-tvOS/Dwifft_tvOS.h
+++ b/Dwifft-tvOS/Dwifft_tvOS.h
@@ -1,0 +1,18 @@
+//
+//  Dwifft_tvOS.h
+//  Dwifft-tvOS
+//
+//  Copyright © 2017 jflinter. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Dwifft_tvOS.
+FOUNDATION_EXPORT double Dwifft_tvOSVersionNumber;
+
+//! Project version string for Dwifft_tvOS.
+FOUNDATION_EXPORT const unsigned char Dwifft_tvOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Dwifft_tvOS/PublicHeader.h>
+
+

--- a/Dwifft-tvOS/Info.plist
+++ b/Dwifft-tvOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Dwifft.xcodeproj/project.pbxproj
+++ b/Dwifft.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		0486A2651EA0A5B600D8093E /* SectionedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0486A2641EA0A5B600D8093E /* SectionedValues.swift */; };
 		0486A2661EA0A64900D8093E /* SectionedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0486A2641EA0A5B600D8093E /* SectionedValues.swift */; };
 		04AC329F1E88AEB000EF63DD /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04AC329E1E88AEB000EF63DD /* SwiftCheck.framework */; };
+		94783CB11EFBA21900841579 /* Dwifft_tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 94783CAF1EFBA21900841579 /* Dwifft_tvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94783CB51EFBA25300841579 /* Dwifft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041EBBAE1B8967C300E113B3 /* Dwifft.swift */; };
+		94783CB61EFBA25300841579 /* SectionedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0486A2641EA0A5B600D8093E /* SectionedValues.swift */; };
+		94783CB71EFBA25300841579 /* Dwifft+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041EBBAF1B8967C300E113B3 /* Dwifft+UIKit.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,6 +44,9 @@
 		041EBBAF1B8967C300E113B3 /* Dwifft+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dwifft+UIKit.swift"; sourceTree = "<group>"; };
 		0486A2641EA0A5B600D8093E /* SectionedValues.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SectionedValues.swift; sourceTree = "<group>"; };
 		04AC329E1E88AEB000EF63DD /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/iOS/SwiftCheck.framework; sourceTree = SOURCE_ROOT; };
+		94783CAD1EFBA21900841579 /* Dwifft_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Dwifft_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		94783CAF1EFBA21900841579 /* Dwifft_tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Dwifft_tvOS.h; sourceTree = "<group>"; };
+		94783CB01EFBA21900841579 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +66,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		94783CA91EFBA21900841579 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -67,6 +81,7 @@
 			children = (
 				041EBB941B89679200E113B3 /* Dwifft */,
 				041EBBA11B89679200E113B3 /* DwifftTests */,
+				94783CAE1EFBA21900841579 /* Dwifft-tvOS */,
 				041EBB931B89679200E113B3 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -76,6 +91,7 @@
 			children = (
 				041EBB921B89679200E113B3 /* Dwifft.framework */,
 				041EBB9D1B89679200E113B3 /* DwifftTests.xctest */,
+				94783CAD1EFBA21900841579 /* Dwifft_tvOS.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -118,6 +134,15 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		94783CAE1EFBA21900841579 /* Dwifft-tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				94783CAF1EFBA21900841579 /* Dwifft_tvOS.h */,
+				94783CB01EFBA21900841579 /* Info.plist */,
+			);
+			path = "Dwifft-tvOS";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -126,6 +151,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				041EBB981B89679200E113B3 /* Dwifft.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		94783CAA1EFBA21900841579 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94783CB11EFBA21900841579 /* Dwifft_tvOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,6 +202,24 @@
 			productReference = 041EBB9D1B89679200E113B3 /* DwifftTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		94783CAC1EFBA21900841579 /* Dwifft-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 94783CB41EFBA21900841579 /* Build configuration list for PBXNativeTarget "Dwifft-tvOS" */;
+			buildPhases = (
+				94783CA81EFBA21900841579 /* Sources */,
+				94783CA91EFBA21900841579 /* Frameworks */,
+				94783CAA1EFBA21900841579 /* Headers */,
+				94783CAB1EFBA21900841579 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Dwifft-tvOS";
+			productName = "Dwifft-tvOS";
+			productReference = 94783CAD1EFBA21900841579 /* Dwifft_tvOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -188,6 +239,9 @@
 						CreatedOnToolsVersion = 6.4;
 						LastSwiftMigration = 0800;
 					};
+					94783CAC1EFBA21900841579 = {
+						CreatedOnToolsVersion = 9.0;
+					};
 				};
 			};
 			buildConfigurationList = 041EBB8C1B89679200E113B3 /* Build configuration list for PBXProject "Dwifft" */;
@@ -204,6 +258,7 @@
 			targets = (
 				041EBB911B89679200E113B3 /* Dwifft */,
 				041EBB9C1B89679200E113B3 /* DwifftTests */,
+				94783CAC1EFBA21900841579 /* Dwifft-tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -217,6 +272,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		041EBB9B1B89679200E113B3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		94783CAB1EFBA21900841579 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -261,6 +323,16 @@
 				041EBBB11B8967C300E113B3 /* Dwifft.swift in Sources */,
 				041EBBA51B89679200E113B3 /* DwifftTests.swift in Sources */,
 				041EBBB31B8967C300E113B3 /* Dwifft+UIKit.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		94783CA81EFBA21900841579 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94783CB71EFBA25300841579 /* Dwifft+UIKit.swift in Sources */,
+				94783CB61EFBA25300841579 /* SectionedValues.swift in Sources */,
+				94783CB51EFBA25300841579 /* Dwifft.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -443,6 +515,71 @@
 			};
 			name = Release;
 		};
+		94783CB21EFBA21900841579 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Dwifft-tvOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.Dwifft-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		94783CB31EFBA21900841579 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Dwifft-tvOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jflinter.Dwifft-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -469,6 +606,15 @@
 			buildConfigurations = (
 				041EBBAC1B89679200E113B3 /* Debug */,
 				041EBBAD1B89679200E113B3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		94783CB41EFBA21900841579 /* Build configuration list for PBXNativeTarget "Dwifft-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				94783CB21EFBA21900841579 /* Debug */,
+				94783CB31EFBA21900841579 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Dwifft.xcodeproj/xcshareddata/xcschemes/Dwifft-tvOS.xcscheme
+++ b/Dwifft.xcodeproj/xcshareddata/xcschemes/Dwifft-tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "94783CAC1EFBA21900841579"
+               BuildableName = "Dwifft_tvOS.framework"
+               BlueprintName = "Dwifft-tvOS"
+               ReferencedContainer = "container:Dwifft.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "94783CAC1EFBA21900841579"
+            BuildableName = "Dwifft_tvOS.framework"
+            BlueprintName = "Dwifft-tvOS"
+            ReferencedContainer = "container:Dwifft.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "94783CAC1EFBA21900841579"
+            BuildableName = "Dwifft_tvOS.framework"
+            BlueprintName = "Dwifft-tvOS"
+            ReferencedContainer = "container:Dwifft.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Dwifft/Dwifft+UIKit.swift
+++ b/Dwifft/Dwifft+UIKit.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 jflinter. All rights reserved.
 //
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 
 import UIKit
 


### PR DESCRIPTION
This adds a check for `os(tvOS)` to the UIKit extensions and makes use of travis' build matrix feature to support multiple targets.