### PR TITLE
Add reload in place capability

### DIFF
--- a/Dwifft/Dwifft.swift
+++ b/Dwifft/Dwifft.swift
@@ -64,14 +64,18 @@ public enum SectionedDiffStep<Section, Value>: CustomDebugStringConvertible {
         case let .sectionDelete(s, _): return s
         }
     }
-
-    public var debugDescription: String {
+    
+    public var encodedValue: String {
         switch self {
         case let .sectionDelete(s, _): return "ds(\(s))"
         case let .sectionInsert(s, _): return "is(\(s))"
         case let .delete(section, row, _): return "d(\(section) \(row))"
         case let .insert(section, row, _): return "i(\(section) \(row))"
         }
+    }
+
+    public var debugDescription: String {
+        return encodedValue
     }
 }
 


### PR DESCRIPTION
As a user of TableViewDiffCalculator, I'd like to minimize unnecessary animations.

This PR transforms subsequent delete+insert calls to reload calls.

This also addresses [#60](https://github.com/jflinter/Dwifft/issues/60).