### PR TITLE
Add support for Swift Package Manager in Xcode 11.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,43 @@
+// swift-tools-version:5.1
+//
+//  Package.swift
+//  Dwifft
+//
+//  Created by Denys Telezhkin on 09.07.2019.
+//  Copyright © 2019 Denys Telezhkin. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import PackageDescription
 
 let package = Package(
     name: "Dwifft",
-    dependencies : [],
-    exclude: [
-        "Carthage",
-        "DwifftTests",
-        "DwifftExample",
-        "docs",
-        "Dwifft.xcworkspace",
-        "scripts",
-    ]
+    platforms: [
+        .iOS(.v8),
+        .tvOS(.v9),
+        .macOS(.v10_11)
+    ],
+    products: [
+        .library(name: "Dwifft", targets: ["Dwifft"])
+    ],
+    targets: [
+        .target(name: "Dwifft", path: "Dwifft")
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,5 @@
 // swift-tools-version:5.1
 //
-//  Package.swift
-//  Dwifft
-//
-//  Created by Denys Telezhkin on 09.07.2019.
-//  Copyright © 2019 Denys Telezhkin. All rights reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import PackageDescription
 


### PR DESCRIPTION
Hey!

This PR adds support for Swift Package Manager in Xcode 11, which finally allows building for other platforms than Linux and MacOS. 

I've set iOS, tvOS and macOS deployment targets to the same targets set in the podspec file. Swift tools version is set to 5.1 because SPM does not integrate to Xcode lower than Xcode 11 anyway. 

Additional information:

https://developer.apple.com/documentation/swift_packages/creating_a_swift_package_with_xcode

https://developer.apple.com/videos/play/wwdc2019/410/