### PR TITLE
Fix warnings for Xcode 12, when used from SPM

### DIFF
--- a/Dwifft/AbstractDiffCalculator.swift
+++ b/Dwifft/AbstractDiffCalculator.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
-
+#if canImport(UIKit)
+import UIKit
+#endif
 /// A parent class for all diff calculators. Don't use it directly.
 public class AbstractDiffCalculator<Section: Equatable, Value: Equatable> {
     
@@ -57,7 +59,7 @@ public class AbstractDiffCalculator<Section: Equatable, Value: Equatable> {
         #if os(iOS) || os(tvOS)
             let row = indexPath.row
         #endif
-        #if os(macOS)
+        #if os(macOS)  || os(watchOS)
             let row = indexPath.item
         #endif
         return self.sectionedValues[indexPath.section].1[row]

--- a/Dwifft/Dwifft.swift
+++ b/Dwifft/Dwifft.swift
@@ -36,10 +36,10 @@ public enum DiffStep<Value> : CustomDebugStringConvertible {
     /// The value to be inserted or deleted.
     public var value: Value {
         switch(self) {
-        case let .insert(j):
-            return j.1
-        case let .delete(j):
-            return j.1
+        case let .insert(_, value):
+            return value
+        case let .delete(_, value):
+            return value
         }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 //
 
 import PackageDescription
@@ -6,8 +6,6 @@ import PackageDescription
 let package = Package(
     name: "Dwifft",
     platforms: [
-        .iOS(.v8),
-        .tvOS(.v9),
         .macOS(.v10_11)
     ],
     products: [


### PR DESCRIPTION
SPM in Xcode 12 bumps minimum iOS deployment target to iOS 9, which produces warnings when trying to use Dwifft.

This PR fixes that by deleting minimum supported platforms from Package.swift. Please note, that macOS platform stays, because Dwifft minimum requirement for MacOS is higher than SwiftPM minimum deployment target. 

I've also fixed couple new warnings from Swift compiler and enabled building for watchOS.
